### PR TITLE
Only run build tokens job when `tokens.json` file is updated

### DIFF
--- a/.github/workflows/test_build_tokens.yml
+++ b/.github/workflows/test_build_tokens.yml
@@ -3,6 +3,7 @@ name: Build Tokens
 on:
   push:
     branches: [ "main" ]
+    paths: [ "tokens/tokens.json" ]
 
   workflow_dispatch:
 


### PR DESCRIPTION
Instead of running the test build tokens GH Action every time, we are limiting it to only run when the tokens are changed